### PR TITLE
#7 Showing marker on hover to the chart data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ For example the plugin allows configuration of the following properties
         {
           "layerName": "sfdem",
           "title": "sfdem",
-          "projection": "EPSG:2154"
         }
     ],
     "distances": [

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ For example the plugin allows configuration of the following properties
     "referentiels": [
         {
           "layerName": "sfdem",
-          "title": "sfdem"
+          "title": "sfdem",
+          "projection": "EPSG:2154"
         }
     ],
     "distances": [

--- a/assets/translations/data.en-US.json
+++ b/assets/translations/data.en-US.json
@@ -17,11 +17,14 @@
               "noLayerSelected": "Please select layer first.",
               "layerNotSupported": "Selected layer is not supported. Please select WMS, WFS or vector layer.",
               "noFeatureInPoint": "Line feature was not found at selected point.",
-              "noLineFeatureFound": "Line feature was not found in imported file."
+              "noLineFeatureFound": "Line feature was not found in imported file.",
+              "fallbackToProjection": "Projection of default referential \"{defaultReferential}\" is not supported. Falling back to referential \"{referential}\" with \"{projection}\" projection."
             },
-            "error": {
+            "errors": {
               "loadingError": "Error loading data for longitudinal profile",
-              "unableToSetupPlugin": "Unable to setup longitudinal profile extension"
+              "unableToSetupPlugin": "Unable to setup longitudinal profile extension",
+              "defaultReferentialNotFound": "Default referential is configured but cannot be found in referentials list. Please update extension configuration.",
+              "projectionNotSupported": "Referential with projection supported by map cannot be found. Please update extension configuration or add desired projection into app configuration."
             },
             "elevation": "Elevation (m)",
             "distance": "Distance (m)",

--- a/assets/translations/data.fr-FR.json
+++ b/assets/translations/data.fr-FR.json
@@ -17,11 +17,15 @@
         "noLayerSelected": "Veuillez d'abord sélectionner le calque.",
         "layerNotSupported": "La couche sélectionnée n'est pas prise en charge. Veuillez sélectionner une couche WMS, WFS ou vectorielle.",
         "noFeatureInPoint": "L'entité linéaire n'a pas été trouvée au point sélectionné.",
-        "noLineFeatureFound": "L'élément de ligne n'a pas été trouvé dans le fichier importé."
+        "noLineFeatureFound": "L'élément de ligne n'a pas été trouvé dans le fichier importé.",
+        "fallbackToProjection": "La projection du référentiel par défaut \"{defaultReferential}\" n'est pas prise en charge. Revenir au référentiel \"{referential}\" avec \"{projection}\" projection."
+
       },
       "error": {
         "loadingError": "Erreur lors du chargement des données pour le profil longitudinal",
-        "unableToSetupPlugin": "Impossible de configurer l'extension du profil longitudinal"
+        "unableToSetupPlugin": "Impossible de configurer l'extension du profil longitudinal",
+        "defaultReferentialNotFound": "Le référentiel par défaut est configuré mais introuvable dans la liste des référentiels. Veuillez mettre à jour la configuration de l'extension.",
+        "projectionNotSupported": "Le référentiel avec projection prise en charge par la carte est introuvable. Veuillez mettre à jour la configuration de l'extension ou ajouter la projection souhaitée dans la configuration de l'application."
       },
       "elevation": "Altitude (m)",
       "distance": "Distance (m)",
@@ -36,6 +40,12 @@
         "heading": "<p><h4>Déposez vos fichiers JSON ici</h4><small>ou</small></p>",
         "selectFiles": "Sélectionner les fichiers...",
         "infoSupported": "<p><small>Types de fichiers pris en charge : GeoJSON</small></p>"
+      }
+    },
+    "plugins": {
+      "LongitudinalProfile": {
+        "description": "Outil qui affiche la fenêtre À propos",
+        "title": "Profil longitudinal"
       }
     }
   }

--- a/assets/translations/data.it-IT.json
+++ b/assets/translations/data.it-IT.json
@@ -17,11 +17,14 @@
         "noLayerSelected": "Seleziona prima il livello.",
         "layerNotSupported": "Il livello selezionato non è supportato. Seleziona il livello WMS, WFS o vettore.",
         "noFeatureInPoint": "L'elemento lineare non è stato trovato nel punto selezionato.",
-        "noLineFeatureFound": "\"La caratteristica linea non è stata trovata nel file importato."
+        "noLineFeatureFound": "La caratteristica linea non è stata trovata nel file importato.",
+        "fallbackToProjection": "La proiezione del referenziale predefinito \"{defaultReferential}\" non è supportata. Tornare al referenziale \"{referential}\" con \"{projection}\" proiezione."
       },
       "error": {
         "loadingError": "Errore nel caricamento dei dati per il profilo longitudinale",
-        "unableToSetupPlugin": "Impossibile impostare l'estensione del profilo longitudinale"
+        "unableToSetupPlugin": "Impossibile impostare l'estensione del profilo longitudinale",
+        "defaultReferentialNotFound": "Il riferimento predefinito è configurato ma non può essere trovato nell'elenco dei riferimenti. Aggiorna la configurazione dell'estensione.",
+        "projectionNotSupported": "Impossibile trovare referenziale con proiezione supportata da mappa. Aggiorna la configurazione dell'estensione o aggiungi la proiezione desiderata nella configurazione dell'app."
       },
       "elevation": "Quota (m)",
       "distance": "Distanza (m)",
@@ -36,6 +39,12 @@
         "heading": "<p><h4>Trascina qui i tuoi file JSON</h4><small>o</small></p>",
         "selectFiles": "Seleziona file...",
         "infoSupported": "<p><small>Tipi di file supportati: GeoJSON</small></p>"
+      }
+    },
+    "plugins": {
+      "LongitudinalProfile": {
+        "description": "Strumento per costruire un profilo longitudinale utilizzando la funzione di linea disegnata, selezionata o importata",
+        "title": "Profilo longitudinale"
       }
     }
   }

--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -56,14 +56,7 @@
     "userSessions": {
       "enabled": true
     },
-    "projectionDefs": [
-      {
-        "code": "EPSG:2154",
-        "def": "+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
-        "extent": [-378305.81, 6093283.21, 1212610.74, 7186901.68],
-        "worldExtent": [-9.86, 41.15, 10.38, 51.56]
-      }
-    ],
+    "projectionDefs": [],
     "initialState": {
       "defaultState": {
         "annotations": {
@@ -294,8 +287,7 @@
               "referentiels": [
                 {
                   "layerName": "sfdem",
-                  "title": "sfdem",
-                  "projection": "EPSG:2154"
+                  "title": "sfdem"
                 }
               ],
               "distances": [
@@ -439,17 +431,13 @@
                 "editCRS": true,
                 "showLabels": true,
                 "showToggle": true,
-                "filterAllowedCRS": ["EPSG:4326", "EPSG:3857", "EPSG:2154"],
-                "additionalCRS": {
-                  "EPSG:2154": { "label": "EPSG:2154" }
-                }
+                "filterAllowedCRS": ["EPSG:4326", "EPSG:3857"],
+                "additionalCRS": {}
               }
             }, {
               "name": "CRSSelector",
               "cfg": {
-                "additionalCRS": {
-                  "EPSG:2154": { "label": "EPSG:2154" }
-                },
+                "additionalCRS": {},
                 "filterAllowedCRS": [
                   "EPSG:4326",
                   "EPSG:3857"

--- a/configs/localConfig.json
+++ b/configs/localConfig.json
@@ -56,7 +56,14 @@
     "userSessions": {
       "enabled": true
     },
-    "projectionDefs": [],
+    "projectionDefs": [
+      {
+        "code": "EPSG:2154",
+        "def": "+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
+        "extent": [-378305.81, 6093283.21, 1212610.74, 7186901.68],
+        "worldExtent": [-9.86, 41.15, 10.38, 51.56]
+      }
+    ],
     "initialState": {
       "defaultState": {
         "annotations": {
@@ -287,7 +294,8 @@
               "referentiels": [
                 {
                   "layerName": "sfdem",
-                  "title": "sfdem"
+                  "title": "sfdem",
+                  "projection": "EPSG:2154"
                 }
               ],
               "distances": [
@@ -431,14 +439,16 @@
                 "editCRS": true,
                 "showLabels": true,
                 "showToggle": true,
-                "filterAllowedCRS": ["EPSG:4326", "EPSG:3857"],
-                "additionalCRS": {}
+                "filterAllowedCRS": ["EPSG:4326", "EPSG:3857", "EPSG:2154"],
+                "additionalCRS": {
+                  "EPSG:2154": { "label": "EPSG:2154" }
+                }
               }
             }, {
               "name": "CRSSelector",
               "cfg": {
                 "additionalCRS": {
-
+                  "EPSG:2154": { "label": "EPSG:2154" }
                 },
                 "filterAllowedCRS": [
                   "EPSG:4326",

--- a/js/extension/actions/__tests__/longitudinal-test.js
+++ b/js/extension/actions/__tests__/longitudinal-test.js
@@ -88,12 +88,14 @@ describe('Test correctness of the actions', () => {
     it('addProfileData', () => {
         const infos = { prop1: true, prop2: 10, prop3: 'test'};
         const points = [[[1, 2, 5], [2, 3, 5]]];
-        const action = addProfileData(infos, points);
+        const projection = 'EPSG:3857';
+        const action = addProfileData(infos, points, projection);
         expect(action).toExist();
         expect(action.type).toBe(ADD_PROFILE_DATA);
         expect(action.infos).toEqual(infos);
         expect(action.points[0]).toEqual(points[0]);
         expect(action.points[1]).toEqual(points[1]);
+        expect(action.projection).toEqual(projection);
     });
 
     it('loading', () => {

--- a/js/extension/actions/longitudinal.js
+++ b/js/extension/actions/longitudinal.js
@@ -19,6 +19,8 @@ export const CHANGE_REFERENTIAL = "LONGITUDINAL:CHANGE_REFERENTIAL";
 export const CHANGE_DISTANCE = "LONGITUDINAL:CHANGE_DISTANCE";
 export const CHANGE_GEOMETRY = "LONGITUDINAL:CHANGE_GEOMETRY";
 export const TOGGLE_MAXIMIZE = "LONGITUDINAL:TOGGLE_MAXIMIZE";
+export const ADD_MARKER = "LONGITUDINAL:ADD_MARKER";
+export const HIDE_MARKER = "LONGITUDINAL:HIDE_MARKER";
 
 export const setup = (config) => ({
     type: SETUP,
@@ -76,4 +78,11 @@ export const changeGeometry = (geometry) => ({
 });
 export const toggleMaximize = () => ({
     type: TOGGLE_MAXIMIZE
+});
+export const addMarker = (point) => ({
+    type: ADD_MARKER,
+    point
+});
+export const hideMarker = () => ({
+    type: HIDE_MARKER
 });

--- a/js/extension/actions/longitudinal.js
+++ b/js/extension/actions/longitudinal.js
@@ -54,10 +54,11 @@ export const toggleMode = (mode) => ({
     mode
 });
 
-export const addProfileData = (infos, points) => ({
+export const addProfileData = (infos, points, projection) => ({
     type: ADD_PROFILE_DATA,
     infos,
-    points
+    points,
+    projection
 });
 
 export const loading = (state) => ({

--- a/js/extension/components/Chart.jsx
+++ b/js/extension/components/Chart.jsx
@@ -40,7 +40,8 @@ const Plot = React.lazy(() => import('@mapstore/components/charts/PlotlyChart'))
  * @prop {object[]} series descriptor for every series. Contains the y axis (or value) `dataKey`
  */
 export default function Chart({
-    onInitialized,
+    onInitialized = () => {},
+    onHover = () => {},
     ...props
 }) {
     const { data, layout, config } = toPlotly(props);
@@ -54,6 +55,7 @@ export default function Chart({
         <Suspense fallback={<LoadingView />}>
             <Plot
                 onInitialized={onInitialized}
+                onHover={onHover}
                 data={data.flat()}
                 layout={layout}
                 config={config}

--- a/js/extension/components/Dock.jsx
+++ b/js/extension/components/Dock.jsx
@@ -24,7 +24,7 @@ import {reproject} from "@mapstore/utils/CoordinatesUtils";
 
 const NavItemT = tooltip(NavItem);
 
-const ChartData = ({ points, messages, loading, maximized, toggleMaximize, boundingRect, dockStyle, referentiels, referential, addMarker, hideMarker, ...props }) => {
+const ChartData = ({ points, projection, messages, loading, maximized, toggleMaximize, boundingRect, dockStyle, referentiels, referential, addMarker, hideMarker, ...props }) => {
     const data = useMemo(() => points ? points.map((point) => ({
         distance: point[0],
         x: point[1],
@@ -36,7 +36,7 @@ const ChartData = ({ points, messages, loading, maximized, toggleMaximize, bound
 
     useEffect(() => {
         if (marker.length) {
-            const point = reproject(marker, referentiels.find(el => el.layerName).projection, 'EPSG:4326');
+            const point = reproject([marker[0], marker[1]], marker[2], 'EPSG:4326');
             addMarker({lng: point.y, lat: point.x, projection: 'EPSG:4326'});
         } else {
             hideMarker();
@@ -55,9 +55,7 @@ const ChartData = ({ points, messages, loading, maximized, toggleMaximize, bound
         cartesian: true,
         popup: false,
         xAxisOpts: {
-            hide: false,
-            format: '.2s',
-            tickSuffix: ' m'
+            hide: false
         },
         yAxisOpts: {
             tickSuffix: ' m'
@@ -97,7 +95,7 @@ const ChartData = ({ points, messages, loading, maximized, toggleMaximize, bound
                                 onHover={(info) => {
                                     const idx = info.points[0].pointIndex;
                                     const point = data[idx];
-                                    setMarker([ point.x, point.y]);
+                                    setMarker([ point.x, point.y, projection]);
                                 }}
                                 {...options}
                                 height={maximized ? height - 115 : 400}

--- a/js/extension/epics/index.js
+++ b/js/extension/epics/index.js
@@ -14,7 +14,8 @@ export {
     onChartPropsChange,
     onDockClosed,
     resetLongitudinalToolOnDrawToolActive,
-    deactivateOnIdentifyEnabledEpic
+    deactivateOnIdentifyEnabledEpic,
+    onMarkerChanged
 } from './setup';
 
 export {

--- a/js/extension/plugins/Extension.jsx
+++ b/js/extension/plugins/Extension.jsx
@@ -24,6 +24,7 @@ import {
     isDockOpen, isInitialized,
     isParametersOpen, isSupportedLayer,
     pointsSelector, referentialSelector,
+    projectionSelector,
     isMaximized, isLoading
 } from "@js/extension/selectors";
 import longitudinal from '@js/extension/reducers/longitudinal';
@@ -59,6 +60,7 @@ const selector = (state) => ({
     showDock: isDockOpen(state),
     infos: infosSelector(state),
     points: pointsSelector(state),
+    projection: projectionSelector(state),
     referential: referentialSelector(state),
     distance: distanceSelector(state),
     dockStyle: mapLayoutValuesSelector(state, { height: true, right: true }, true),

--- a/js/extension/plugins/Extension.jsx
+++ b/js/extension/plugins/Extension.jsx
@@ -36,7 +36,9 @@ import {
     changeReferential,
     changeDistance,
     changeGeometry,
-    toggleMaximize
+    toggleMaximize,
+    addMarker,
+    hideMarker
 } from "@js/extension/actions/longitudinal";
 import { setControlProperty } from "@mapstore/actions/controls";
 import { warning } from '@mapstore/actions/notifications';
@@ -102,7 +104,9 @@ export default {
             setup,
             tearDown,
             exportCSV,
-            warning
+            warning,
+            addMarker,
+            hideMarker
         })(Main),
     containers: {
         SidebarMenu: {

--- a/js/extension/reducers/longitudinal.js
+++ b/js/extension/reducers/longitudinal.js
@@ -23,6 +23,7 @@ const DEFAULT_STATE = {
     geometry: false,
     infos: false,
     points: false,
+    projection: false,
     maximized: false,
     config: {}
 };
@@ -71,11 +72,12 @@ export default function longitudinal(state = DEFAULT_STATE, action) {
             loading: action.state
         };
     case ADD_PROFILE_DATA:
-        const {infos, points} = action;
+        const {infos, points, projection} = action;
         return {
             ...state,
             infos,
-            points
+            points,
+            projection
         };
     case TOGGLE_MODE:
         return {

--- a/js/extension/selectors/index.js
+++ b/js/extension/selectors/index.js
@@ -31,6 +31,7 @@ export const isActiveMenu = (state) => isParametersOpen(state) || dataSourceMode
 
 export const infosSelector = (state) => state?.longitudinal?.infos;
 export const pointsSelector = (state) => state?.longitudinal?.points;
+export const projectionSelector = (state) => state?.longitudinal?.projection;
 export const configSelector = (state) => state?.longitudinal?.config;
 export const referentialSelector = (state) => configSelector(state)?.referential;
 export const distanceSelector = (state) => configSelector(state)?.distance;

--- a/js/extension/selectors/index.js
+++ b/js/extension/selectors/index.js
@@ -6,10 +6,16 @@
  * LICENSE file in the root directory of this source tree.
 */
 
-import {CONTROL_DOCK_NAME, CONTROL_NAME, CONTROL_PROPERTIES_NAME} from "@js/extension/constants";
+import {
+    CONTROL_DOCK_NAME,
+    CONTROL_NAME,
+    CONTROL_PROPERTIES_NAME,
+    LONGITUDINAL_VECTOR_LAYER_ID
+} from "@js/extension/constants";
 import {getSelectedLayer} from "@mapstore/selectors/layers";
 import {mapSelector} from "@mapstore/selectors/map";
-import {get} from "lodash";
+import {get, head} from "lodash";
+import {additionalLayersSelector} from "@mapstore/selectors/additionallayers";
 
 export const isInitialized = (state) => state?.longitudinal?.initialized;
 export const isLoading = (state) => state?.longitudinal?.loading;
@@ -41,3 +47,4 @@ export const isListeningClick = (state) => !!(get(mapSelector(state), 'eventList
 
 export const isMaximized = (state) => state?.longitudinal?.maximized;
 
+export const vectorLayerFeaturesSelector = (state) => head(additionalLayersSelector(state).filter(l => l.id === LONGITUDINAL_VECTOR_LAYER_ID))?.options?.features;


### PR DESCRIPTION
**Improvements:**
- Added support of showing a marker on hover over chart data points.

**Not covered by this PR:**

- Toolbar buttons above the chart and their styles: this is a basic style of React Plotly integration. Light gray buttons are inactive, more prominent one is the one that currently selected. Unfortunately there is no easy straight-forward way to style them differently. They are used with the same style in widgets, e.g. in charts on map.
- Translations on the context creation wizard: it is the same for other extension in general (like Cadastrapp) not part of the core. title and description are taken from assets/index.json. Plugins have titles and description translated in locale files, but  translations for title and description are not taken locales for extensions, so this issue need an enhancement somehow MapStore side.